### PR TITLE
Add missing service discovery in nginx config

### DIFF
--- a/nextcloud/rootfs/nginx/sites-enabled/nginx.conf
+++ b/nextcloud/rootfs/nginx/sites-enabled/nginx.conf
@@ -20,6 +20,10 @@ server {
             access_log off;
         }
 
+        rewrite ^/.well-known/host-meta /public.php?service=host-meta last;
+        rewrite ^/.well-known/host-meta.json /public.php?service=host-meta-json last;
+        rewrite ^/.well-known/webfinger /public.php?service=webfinger last;
+
         location = /.well-known/carddav {
             return 301 https://$host/remote.php/dav;
         }


### PR DESCRIPTION
See https://docs.nextcloud.com/server/15/admin_manual/issues/general_troubleshooting.html#service-discovery
Rules as suggest in https://docs.nextcloud.com/server/15/admin_manual/installation/nginx.html

The last rule is needed by the (new) [Social App](https://apps.nextcloud.com/apps/social), see: ![webfinger_social](https://user-images.githubusercontent.com/1449568/49864673-4e7d6d80-fe03-11e8-947b-30c1ed740b50.png)