### PR TITLE
Disable fastcgi_intercept_errors to fix CARDDAV on OSX.

### DIFF
--- a/nextcloud/rootfs/nginx/sites-enabled/nginx.conf
+++ b/nextcloud/rootfs/nginx/sites-enabled/nginx.conf
@@ -53,7 +53,7 @@ server {
             fastcgi_param modHeadersAvailable true;
             fastcgi_param front_controller_active true;
             fastcgi_pass unix:/php/run/php-fpm.sock;
-            fastcgi_intercept_errors on;
+            fastcgi_intercept_errors off;
             fastcgi_request_buffering off;
             fastcgi_read_timeout 1200;
         }


### PR DESCRIPTION
Multiple addressbooks seems to be challenging on OSX. This should make it
work again as described in
https://github.com/nextcloud/contacts/issues/399#issuecomment-451651613