### PR TITLE
add ocm-provider in nginx

### DIFF
--- a/nextcloud/rootfs/nginx/sites-enabled/nginx.conf
+++ b/nextcloud/rootfs/nginx/sites-enabled/nginx.conf
@@ -44,7 +44,7 @@ server {
             deny all;
         }
 
-        location ~ ^/(?:index|remote|public|cron|core/ajax/update|status|ocs/v[12]|updater/.+|ocs-provider/.+|core/templates/40[34])\.php(?:$|/) {
+        location ~ ^\/(?:index|remote|public|cron|core\/ajax\/update|status|ocs\/v[12]|updater\/.+|ocs-provider\/.+|ocm-provider\/.+)\.php(?:$|\/) {
             include /nginx/conf/fastcgi_params;
             fastcgi_split_path_info ^(.+\.php)(/.*)$;
             fastcgi_hide_header X-Powered-By;
@@ -58,7 +58,7 @@ server {
             fastcgi_read_timeout 1200;
         }
 
-        location ~ ^/(?:updater|ocs-provider)(?:$|/) {
+        location ~ ^\/(?:updater|ocs-provider|ocm-provider)(?:$|\/) {
             try_files $uri/ =404;
             index index.php;
         }

--- a/nextcloud/rootfs/nginx/sites-enabled/nginx.conf
+++ b/nextcloud/rootfs/nginx/sites-enabled/nginx.conf
@@ -44,7 +44,7 @@ server {
             deny all;
         }
 
-        location ~ ^\/(?:index|remote|public|cron|core\/ajax\/update|status|ocs\/v[12]|updater\/.+|ocs-provider\/.+|ocm-provider\/.+)\.php(?:$|\/) {
+        location ~ ^/(?:index|remote|public|cron|core/ajax/update|status|ocs/v[12]|updater/.+|ocs-provider/.+|ocm-provider/.+)\.php(?:$|/) {
             include /nginx/conf/fastcgi_params;
             fastcgi_split_path_info ^(.+\.php)(/.*)$;
             fastcgi_hide_header X-Powered-By;
@@ -58,7 +58,7 @@ server {
             fastcgi_read_timeout 1200;
         }
 
-        location ~ ^\/(?:updater|ocs-provider|ocm-provider)(?:$|\/) {
+        location ~ ^/(?:updater|ocs-provider|ocm-provider)(?:$|/) {
             try_files $uri/ =404;
             index index.php;
         }


### PR DESCRIPTION
The latest version of Nextcloud requires an additional entry in Nginx vhost. This is displayed under "Security & setup warnings".  

warning:

> Your web server is not properly set up to resolve "/ocm-provider/". This is most likely related to a web server configuration that was not updated to deliver this folder directly. Please compare your configuration against the shipped rewrite rules in ".htaccess" for Apache or the provided one in the documentation for Nginx at it's documentation page. On Nginx those are typically the lines starting with "location ~" that need an update.

I have now adjusted this after the documentation.
https://docs.nextcloud.com/server/15/admin_manual/installation/nginx.html?highlight=ocm%20provider